### PR TITLE
Changing color of search views to match other actionbar items

### DIFF
--- a/mobile/src/main/java/me/calebjones/spacelaunchnow/ui/main/launches/UpcomingLaunchesFragment.java
+++ b/mobile/src/main/java/me/calebjones/spacelaunchnow/ui/main/launches/UpcomingLaunchesFragment.java
@@ -1,6 +1,7 @@
 package me.calebjones.spacelaunchnow.ui.main.launches;
 
 import android.content.Context;
+import android.graphics.Color;
 import android.os.Bundle;
 
 import androidx.annotation.Nullable;
@@ -14,6 +15,7 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ImageView;
 
 import com.afollestad.aesthetic.Aesthetic;
 import com.crashlytics.android.Crashlytics;
@@ -294,6 +296,15 @@ public class UpcomingLaunchesFragment extends BaseFragment implements SearchView
         final MenuItem item = menu.findItem(R.id.action_search);
         searchView = (SearchView) MenuItemCompat.getActionView(item);
         searchView.setOnQueryTextListener(this);
+        final ImageView searchIcon = searchView.findViewById(androidx.appcompat.R.id.search_button);
+        searchIcon.setColorFilter(Color.WHITE);
+        final ImageView cancelButton
+                = searchView.findViewById(androidx.appcompat.R.id.search_close_btn);
+        cancelButton.setColorFilter(Color.WHITE);
+        final SearchView.SearchAutoComplete searchAutoComplete = searchView
+                .findViewById(androidx.appcompat.R.id.search_src_text);
+        searchAutoComplete.setHintTextColor(getResources().getColor(android.R.color.white));
+        searchAutoComplete.setTextColor(getResources().getColor(android.R.color.white));
     }
 
     @Override


### PR DESCRIPTION
SearchView items were showing up black, while all other parts of the
actionBar are white by default.

# Before
![Screenshot_20190630-180858](https://user-images.githubusercontent.com/389169/60408824-57eadf00-9b75-11e9-8342-14d3496b9e82.png)
![Screenshot_20190630-180907](https://user-images.githubusercontent.com/389169/60408825-57eadf00-9b75-11e9-8557-9b4e599b838a.png)

# After
![Screenshot_20190630-202550](https://user-images.githubusercontent.com/389169/60408826-57eadf00-9b75-11e9-831b-171334edf4af.png)
![Screenshot_20190630-202559](https://user-images.githubusercontent.com/389169/60408827-57eadf00-9b75-11e9-9f62-b4071d0dabac.png)
